### PR TITLE
Model toggle functionality from main dashboard

### DIFF
--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -1638,6 +1638,15 @@
             for (const [name, modelStatus] of Object.entries(status)) {
                 modelsContainer.innerHTML += renderModel(name, modelStatus);
             }
+
+            document.querySelectorAll('#modelsContainer .model-toggle').forEach(toggle => {
+                toggle.addEventListener('change', function() {
+                    const modelName = this.dataset.model;
+                    const enabled = this.checked;
+                    
+                    socket.emit('toggle-model', { modelName, enabled });
+                });
+            });
         });
 
         socket.on('prediction-history', function(history) {


### PR DESCRIPTION
This pull request adds functionality to allow users to toggle the status of models directly from the dashboard. The change includes adding event listeners to handle user interactions and communicate updates to the server.

**Dashboard functionality update:**

* [`src/views/dashboard.ejs`](diffhunk://#diff-4b23da7ac7d2cbcc57aacff1deff85d57339c80d556af2fc595fb7bb96cb3ff5R1641-R1649): Introduced event listeners for `.model-toggle` elements to handle toggling model statuses. When a toggle is changed, the model's name and new status are sent to the server via a `socket.emit` call.

Closes #4 