### PR TITLE
Add signal preview charts

### DIFF
--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -903,7 +903,24 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <pre id="filePreviewContent" class="bg-light p-3 rounded" style="max-height: 400px; overflow: auto;"></pre>
+                    <ul class="nav nav-tabs mb-3" id="filePreviewTabs" role="tablist">
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link active" id="graph-tab" data-bs-toggle="tab" data-bs-target="#graph-view" type="button" role="tab" aria-controls="graph-view" aria-selected="true">Graph</button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link" id="raw-tab" data-bs-toggle="tab" data-bs-target="#raw-view" type="button" role="tab" aria-controls="raw-view" aria-selected="false">Raw Text</button>
+                        </li>
+                    </ul>
+                    <div class="tab-content" id="filePreviewTabContent">
+                        <div class="tab-pane fade show active" id="graph-view" role="tabpanel" aria-labelledby="graph-tab">
+                            <div class="chart-container" style="position: relative; height:400px;">
+                                <canvas id="signalChart"></canvas>
+                            </div>
+                        </div>
+                        <div class="tab-pane fade" id="raw-view" role="tabpanel" aria-labelledby="raw-tab">
+                            <pre id="filePreviewContent" class="bg-light p-3 rounded" style="max-height: 400px; overflow: auto;"></pre>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -1739,10 +1756,79 @@
             }
         };
 
-        // File preview. TODO: Show graph instead of text
-        function showFilePreview(fileName, content) {
+        // File preview with graph visualization
+        function showFilePreview(fileName, content, anomalyTime = null) {
+            // Destroy existing chart if any
+            let chartInstance = window.signalChartInstance;
+            if (chartInstance) {
+                chartInstance.destroy();
+            }
+
             document.getElementById('filePreviewTitle').textContent = fileName;
             document.getElementById('filePreviewContent').textContent = content;
+
+            // Parse content
+            const lines = content.trim().split('\n');
+            const times = [];
+            const values = [];
+
+            lines.forEach(line => {
+                const parts = line.trim().split(/\s+/);
+                if (parts.length >= 2) {
+                    const time = parseFloat(parts[0]);
+                    const value = parseFloat(parts[1]);
+                    if (!isNaN(time) && !isNaN(value)) {
+                        times.push(time);
+                        values.push(value);
+                    }
+                }
+            });
+
+            const ctx = document.getElementById('signalChart').getContext('2d');
+            window.signalChartInstance = new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: times,
+                    datasets: [{
+                        label: fileName,
+                        data: values,
+                        borderColor: 'rgb(75, 192, 192)',
+                        borderWidth: 1,
+                        pointRadius: 0,
+                        tension: 0.1,
+                        parsing: {
+                            xAxisKey: 'time',
+                            yAxisKey: 'value'
+                        }
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    scales: {
+                        x: {
+                            type: 'linear',
+                            title: {
+                                display: true,
+                                text: 'Time'
+                            }
+                        },
+                        y: {
+                            title: {
+                                display: true,
+                                text: 'Signal Value'
+                            }
+                        }
+                    },
+                    plugins: {
+                        tooltip: {
+                            mode: 'index',
+                            intersect: false,
+                        }
+                    }
+                }
+            });
+
             filePreviewModal.show();
         }
 

--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -166,6 +166,291 @@
         .collapsed .collapse-indicator {
             transform: rotate(-90deg);
         }
+
+        /* Preview charts */
+        .chart-grid {
+            display: grid;
+            gap: 25px;
+            margin-top: 20px;
+            padding: 10px 0;
+        }
+
+        .chart-grid.single-chart {
+            grid-template-columns: 1fr;
+        }
+
+        .chart-grid.multiple-charts-1 {
+            grid-template-columns: 1fr;
+        }
+
+        .chart-grid.multiple-charts-2 {
+            grid-template-columns: 1fr 1fr;
+        }
+
+        .chart-grid.multiple-charts-3 {
+            grid-template-columns: 1fr;
+        }
+
+        .chart-grid.multiple-charts-4 {
+            grid-template-columns: 1fr;
+        }
+
+        .chart-grid.multiple-charts-more {
+            grid-template-columns: 1fr;
+        }
+
+        .chart-container-preview {
+            position: relative;
+            height: 400px;
+            background: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 8px;
+            padding: 20px;
+            margin-bottom: 20px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            transition: box-shadow 0.3s ease, transform 0.2s ease;
+        }
+
+        .chart-container-preview:hover {
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+            transform: translateY(-2px);
+        }
+
+        .chart-title {
+            text-align: center;
+            font-weight: 600;
+            margin-bottom: 15px;
+            color: #495057;
+            font-size: 16px;
+            padding: 10px 0;
+            border-bottom: 2px solid #dee2e6;
+            background: rgba(255, 255, 255, 0.8);
+            border-radius: 4px 4px 0 0;
+            margin: -20px -20px 15px -20px;
+            padding: 15px 20px;
+        }
+
+        .chart-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 10px;
+            padding: 5px 0;
+        }
+
+        .chart-header .chart-title {
+            margin-bottom: 0;
+            flex: 1;
+            text-align: left;
+        }
+
+        .fullscreen-btn {
+            background: #007bff;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            padding: 5px 10px;
+            font-size: 12px;
+            cursor: pointer;
+            transition: background-color 0.2s;
+        }
+
+        .fullscreen-btn:hover {
+            background: #0056b3;
+        }
+
+        .fullscreen-modal {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100vw;
+            height: 100vh;
+            background: rgba(0, 0, 0, 0.9);
+            z-index: 9999;
+            display: none;
+            flex-direction: column;
+        }
+
+        .fullscreen-modal-header {
+            background: #333;
+            color: white;
+            padding: 15px 20px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            flex-shrink: 0;
+        }
+
+        .fullscreen-modal-title {
+            font-size: 18px;
+            font-weight: bold;
+        }
+
+        .fullscreen-close-btn {
+            background: #dc3545;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            padding: 8px 12px;
+            cursor: pointer;
+            font-size: 14px;
+        }
+
+        .fullscreen-close-btn:hover {
+            background: #c82333;
+        }
+
+        .fullscreen-chart-container {
+            flex: 1;
+            padding: 20px;
+            position: relative;
+            overflow-y: auto;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .fullscreen-single-chart {
+            flex: 1;
+            min-height: 0;
+        }
+
+        .fullscreen-multiple-charts {
+            display: grid;
+            gap: 20px;
+            height: 100%;
+            align-content: stretch;
+        }
+
+        .fullscreen-multiple-charts.charts-1 {
+            grid-template-columns: 1fr;
+        }
+
+        .fullscreen-multiple-charts.charts-2 {
+            grid-template-columns: 1fr 1fr;
+        }
+
+        .fullscreen-multiple-charts.charts-3 {
+            grid-template-columns: 1fr;
+        }
+
+        .fullscreen-multiple-charts.charts-4 {
+            grid-template-columns: 1fr;
+        }
+
+        .fullscreen-multiple-charts.charts-more {
+            grid-template-columns: 1fr;
+        }
+
+        .fullscreen-chart-item {
+            position: relative;
+            background: rgba(248, 249, 250, 0.95);
+            border-radius: 8px;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            border: 1px solid rgba(222, 226, 230, 0.5);
+            min-height: 400px;
+        }
+
+        .fullscreen-chart-title {
+            text-align: center;
+            font-weight: 600;
+            margin-bottom: 15px;
+            color: #495057;
+            font-size: 16px;
+            flex-shrink: 0;
+            padding: 15px 20px;
+            border-bottom: 2px solid rgba(222, 226, 230, 0.6);
+            background: rgba(255, 255, 255, 0.9);
+            border-radius: 4px 4px 0 0;
+            margin: -20px -20px 15px -20px;
+        }
+
+        .fullscreen-chart-item canvas {
+            flex: 1;
+            width: 100% !important;
+            min-height: 300px !important;
+        }
+
+        @media (max-width: 1200px) {
+            .fullscreen-multiple-charts.charts-2 {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        @media (max-width: 768px) {
+            .fullscreen-multiple-charts.charts-2 {
+                grid-template-columns: 1fr;
+            }
+
+            .chart-grid.multiple-charts-2 {
+                grid-template-columns: 1fr;
+            }
+
+            .fullscreen-chart-item {
+                padding: 15px;
+                min-height: 250px;
+            }
+
+            .chart-container-preview {
+                height: 300px;
+                padding: 15px;
+            }
+
+            .chart-title {
+                font-size: 14px;
+                margin: -15px -15px 15px -15px;
+                padding: 12px 15px;
+            }
+
+            .fullscreen-modal-header {
+                padding: 10px 15px;
+            }
+
+            .fullscreen-modal-title {
+                font-size: 16px;
+            }
+        }
+
+        .preview-selection-item {
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            padding: 10px;
+            margin-bottom: 10px;
+            background-color: #fff;
+            cursor: pointer;
+            transition: border-color 0.2s;
+        }
+
+        .preview-selection-item:hover {
+            border-color: #007bff;
+        }
+
+        .preview-selection-item.selected {
+            border-color: #007bff;
+            background-color: #f8f9ff;
+        }
+
+        .signal-selection-item {
+            border: 1px solid #eee;
+            border-radius: 4px;
+            padding: 8px;
+            margin: 5px 0;
+            background-color: #f9f9f9;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+
+        .signal-selection-item:hover {
+            border-color: #007bff;
+            background-color: #f0f8ff;
+        }
+
+        .signal-selection-item.selected {
+            border-color: #007bff;
+            background-color: #e3f2fd;
+            font-weight: bold;
+        }
     </style>
 </head>
 <body>
@@ -218,6 +503,9 @@
                     </li>
                     <li class="nav-item" role="presentation">
                         <button class="nav-link" id="history-tab" data-bs-toggle="tab" data-bs-target="#history" type="button" role="tab" aria-controls="history" aria-selected="false">History</button>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link" id="preview-tab" data-bs-toggle="tab" data-bs-target="#preview" type="button" role="tab" aria-controls="preview" aria-selected="false">Preview</button>
                     </li>
                 </ul>
             </div>
@@ -428,6 +716,144 @@
                     </div>
                 </div>
             </div>
+
+            <!-- Preview Tab -->
+            <div class="tab-pane fade" id="preview" role="tabpanel" aria-labelledby="preview-tab">
+                <div class="row">
+                    <div class="col-md-12 mb-4">
+                        <div class="card">
+                            <div class="card-header bg-primary text-white">
+                                Signal Preview &amp; Visualization
+                            </div>
+                            <div class="card-body">
+                                <div class="alert alert-info mb-3">
+                                    <strong>Preview Options:</strong> Visualize signals from your discharge data in different ways.
+                                </div>
+
+                                <!-- Preview Mode Selection -->
+                                <div class="row mb-4">
+                                    <div class="col-md-6">
+                                        <div class="card preview-selection-item" id="singleChartMode" style="cursor: pointer;">
+                                            <div class="card-body text-center">
+                                                <h5 class="card-title">Single Chart Mode</h5>
+                                                <p class="card-text">Plot signals from different discharges on one chart for comparison</p>
+                                                <button class="btn btn-primary" onclick="selectPreviewMode('single')">Select</button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <div class="card preview-selection-item" id="multipleChartsMode" style="cursor: pointer;">
+                                            <div class="card-body text-center">
+                                                <h5 class="card-title">Multiple Charts Mode</h5>
+                                                <p class="card-text">Plot all signals from one discharge on separate charts</p>
+                                                <button class="btn btn-primary" onclick="selectPreviewMode('multiple')">Select</button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- Single Chart Mode Interface -->
+                                <div id="singleChartInterface" class="preview-interface" style="display: none;">
+                                    <h6>Single Chart Mode - Signal Comparison</h6>
+                                    <div class="row">
+                                        <div class="col-md-4">
+                                            <div class="card">
+                                                <div class="card-header">
+                                                    <h6 class="mb-0">Upload Signal Files</h6>
+                                                </div>
+                                                <div class="card-body">
+                                                    <div class="mb-3">
+                                                        <label for="singleModeFiles" class="form-label">Select signal files (.txt):</label>
+                                                        <input type="file" class="form-control" id="singleModeFiles" multiple accept=".txt" onchange="loadSingleModeFiles()">
+                                                        <small class="form-text text-muted">Select multiple .txt files to compare</small>
+                                                    </div>
+                                                    <div class="mb-3">
+                                                        <label class="form-label">Loaded Files:</label>
+                                                        <div id="singleModeFilesList" class="overflow-auto" style="max-height: 200px; border: 1px solid #dee2e6; padding: 10px; border-radius: 4px;">
+                                                            <small class="text-muted">No files loaded</small>
+                                                        </div>
+                                                    </div>
+                                                    <div class="d-grid gap-2">
+                                                        <button class="btn btn-success" onclick="plotSingleChart()" id="plotSingleBtn" disabled>Plot Comparison Chart</button>
+                                                        <button class="btn btn-secondary" onclick="clearSingleChart()">Clear Chart</button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="col-md-8">
+                                            <div class="card">
+                                                <div class="card-header d-flex justify-content-between align-items-center">
+                                                    <h6 class="mb-0">Chart Visualization</h6>
+                                                    <button class="btn btn-sm btn-outline-secondary fullscreen-btn" id="singleChartFullscreenBtn" onclick="openSingleChartFullscreen()" disabled>
+                                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                                                            <path d="M5.828 10.172a.5.5 0 0 0-.707 0l-4.096 4.096V11.5a.5.5 0 0 0-1 0v3.975a.5.5 0 0 0 .5.5H4.5a.5.5 0 0 0 0-1H1.732l4.096-4.096a.5.5 0 0 0 0-.707zm4.344 0a.5.5 0 0 1 .707 0l4.096 4.096V11.5a.5.5 0 1 1 1 0v3.975a.5.5 0 0 1-.5.5H11.5a.5.5 0 0 1 0-1h2.768l-4.096-4.096a.5.5 0 0 1 0-.707zm0-4.344a.5.5 0 0 0 .707 0l4.096-4.096V4.5a.5.5 0 1 0 1 0V.525a.5.5 0 0 0-.5-.5H11.5a.5.5 0 0 0 0 1h2.768l-4.096 4.096a.5.5 0 0 0 0 .707zm-4.344 0a.5.5 0 0 1-.707 0L1.025 1.732V4.5a.5.5 0 0 1-1 0V.525a.5.5 0 0 1 .5-.5H4.5a.5.5 0 0 1 0 1H1.732l4.096 4.096a.5.5 0 0 1 0 .707z"/>
+                                                        </svg>
+                                                    </button>
+                                                </div>
+                                                <div class="card-body" style="background-color: #f8f9fa;">
+                                                    <div class="chart-container-preview">
+                                                        <canvas id="singleComparisonChart"></canvas>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- Multiple Charts Mode Interface -->
+                                <div id="multipleChartsInterface" class="preview-interface" style="display: none;">
+                                    <h6>Multiple Charts Mode - Individual Signal Plots</h6>
+                                    <div class="row">
+                                        <div class="col-md-3">
+                                            <div class="card">
+                                                <div class="card-header">
+                                                    <h6 class="mb-0">Upload Signal Files</h6>
+                                                </div>
+                                                <div class="card-body">
+                                                    <div class="mb-3">
+                                                        <label for="multipleModeFiles" class="form-label">Select signal files (.txt):</label>
+                                                        <input type="file" class="form-control" id="multipleModeFiles" multiple accept=".txt" onchange="loadMultipleModeFiles()">
+                                                        <small class="form-text text-muted">Select multiple .txt files to plot separately</small>
+                                                    </div>
+                                                    <div class="mb-3">
+                                                        <label class="form-label">Loaded Files:</label>
+                                                        <div id="multipleModeFilesList" class="overflow-auto" style="max-height: 200px;">
+                                                            <small class="text-muted">No files loaded</small>
+                                                        </div>
+                                                    </div>
+                                                    <div class="d-grid gap-2">
+                                                        <button class="btn btn-success" onclick="plotMultipleCharts()" id="plotMultipleBtn" disabled>Plot All Charts</button>
+                                                        <button class="btn btn-secondary" onclick="clearMultipleCharts()">Clear Charts</button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="col-md-9">
+                                            <div class="card">
+                                                <div class="card-header d-flex justify-content-between align-items-center">
+                                                    <h6 class="mb-0">Signal Charts</h6>
+                                                    <button class="btn btn-sm btn-outline-secondary fullscreen-btn" id="multipleChartsFullscreenBtn" onclick="openMultipleChartsFullscreen()" disabled>
+                                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                                                            <path d="M5.828 10.172a.5.5 0 0 0-.707 0l-4.096 4.096V11.5a.5.5 0 0 0-1 0v3.975a.5.5 0 0 0 .5.5H4.5a.5.5 0 0 0 0-1H1.732l4.096-4.096a.5.5 0 0 0 0-.707zm4.344 0a.5.5 0 0 1 .707 0l4.096 4.096V11.5a.5.5 0 1 1 1 0v3.975a.5.5 0 0 1-.5.5H11.5a.5.5 0 0 1 0-1h2.768l-4.096-4.096a.5.5 0 0 1 0-.707zm0-4.344a.5.5 0 0 0 .707 0l4.096-4.096V4.5a.5.5 0 1 0 1 0V.525a.5.5 0 0 0-.5-.5H11.5a.5.5 0 0 0 0 1h2.768l-4.096 4.096a.5.5 0 0 0 0 .707zm-4.344 0a.5.5 0 0 1-.707 0L1.025 1.732V4.5a.5.5 0 0 1-1 0V.525a.5.5 0 0 1 .5-.5H4.5a.5.5 0 0 1 0 1H1.732l4.096 4.096a.5.5 0 0 1 0 .707z"/>
+                                                        </svg>
+                                                    </button>
+                                                </div>
+                                                <div class="card-body" style="background-color: #f8f9fa;">
+                                                    <div id="multipleChartsContainer" class="chart-grid">
+                                                        <div class="text-center text-muted">
+                                                            <p>Upload signal files and click "Plot All Charts" to view them</p>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -483,7 +909,26 @@
         </div>
     </div>
 
+    <!-- Fullscreen Chart Modal -->
+    <div id="fullscreenModal" class="fullscreen-modal">
+        <div class="fullscreen-modal-header">
+            <div class="fullscreen-modal-title" id="fullscreenChartTitle">Chart Fullscreen View</div>
+            <button class="fullscreen-close-btn" onclick="closeFullscreenChart()">Close</button>
+        </div>
+        <div class="fullscreen-chart-container">
+            <!-- Single chart container -->
+            <div id="fullscreenSingleChart" class="fullscreen-single-chart" style="display: none;">
+                <canvas id="fullscreenChart"></canvas>
+            </div>
+            <!-- Multiple charts container -->
+            <div id="fullscreenMultipleCharts" class="fullscreen-multiple-charts" style="display: none;">
+                <!-- Multiple charts will be added here dynamically -->
+            </div>
+        </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/node_modules/chart.js/dist/chart.umd.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script>
         // Connect to the Socket.io server
@@ -1617,17 +2062,429 @@
 
             document.getElementById('configModal').addEventListener('show.bs.modal', function() {
                 fetch('/api/config')
-                .then(response => response.json())
-                .then(config => {
-                    renderModelConfig(config.models);
-                })
-                .catch(error => {
-                    document.getElementById('modelConfigContainer').innerHTML = `
+                    .then(response => response.json())
+                    .then(config => {
+                        renderModelConfig(config.models);
+                    })
+                    .catch(error => {
+                        document.getElementById('modelConfigContainer').innerHTML = `
                         <div class="alert alert-danger">
                             Error at loading configuration: ${error.message}
                         </div>
                     `;
+                    });
+            });
+
+            // Preview Tab Functions
+            let currentPreviewMode = null;
+            let selectedSignalsForComparison = [];
+            let selectedSignalsForMultiple = [];
+            let singleComparisonChart = null;
+            let multipleChartsArray = [];
+
+            function selectPreviewMode(mode) {
+                currentPreviewMode = mode;
+
+                document.getElementById('singleChartInterface').style.display = 'none';
+                document.getElementById('multipleChartsInterface').style.display = 'none';
+
+                if (mode === 'single') {
+                    document.getElementById('singleChartInterface').style.display = 'block';
+                } else if (mode === 'multiple') {
+                    document.getElementById('multipleChartsInterface').style.display = 'block';
+                }
+
+                document.querySelectorAll('.preview-selection-item').forEach(item => {
+                    item.classList.remove('border-primary');
                 });
+
+                if (mode === 'single') {
+                    document.getElementById('singleChartMode').classList.add('border-primary');
+                } else {
+                    document.getElementById('multipleChartsMode').classList.add('border-primary');
+                }
+            }
+
+            function parseSignalData(content) {
+                const lines = content.split('\n').filter(line => line.trim());
+                const data = [];
+
+                for (const line of lines) {
+                    const parts = line.trim().split(/\s+/);
+                    if (parts.length >= 2) {
+                        const time = parseFloat(parts[0]);
+                        const value = parseFloat(parts[1]);
+                        if (!isNaN(time) && !isNaN(value)) {
+                            data.push({ x: time, y: value });
+                        }
+                    }
+                }
+                return data;
+            }
+
+            function plotSingleChart() {
+                if (selectedSignalsForComparison.length === 0) return;
+
+                const ctx = document.getElementById('singleComparisonChart').getContext('2d');
+
+                if (singleComparisonChart) {
+                    singleComparisonChart.destroy();
+                }
+
+                const datasets = selectedSignalsForComparison.map((signal, index) => {
+                    const data = parseSignalData(signal.content);
+                    const colors = [
+                        'rgb(255, 99, 132)',
+                        'rgb(54, 162, 235)',
+                        'rgb(255, 205, 86)',
+                        'rgb(75, 192, 192)',
+                        'rgb(153, 102, 255)',
+                        'rgb(255, 159, 64)',
+                        'rgb(199, 199, 199)',
+                        'rgb(83, 102, 147)'
+                    ];
+
+                    return {
+                        label: signal.name,
+                        data: data,
+                        borderColor: colors[index % colors.length],
+                        backgroundColor: colors[index % colors.length] + '20',
+                        fill: false,
+                        tension: 0.1,
+                        pointRadius: 0
+                    };
+                });
+
+                singleComparisonChart = new Chart(ctx, {
+                    type: 'line',
+                    data: { datasets: datasets },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        scales: {
+                            x: {
+                                type: 'linear',
+                                position: 'bottom',
+                                title: { display: true, text: 'Time' }
+                            },
+                            y: { title: { display: true, text: 'Signal Value' } }
+                        },
+                        plugins: {
+                            title: { display: true, text: 'Signal Comparison Chart' },
+                            legend: { display: true, position: 'top' },
+                            tooltip: { mode: 'index', intersect: false }
+                        }
+                    }
+                });
+
+                document.getElementById('singleChartFullscreenBtn').disabled = false;
+            }
+
+            function clearSingleChart() {
+                if (singleComparisonChart) {
+                    singleComparisonChart.destroy();
+                    singleComparisonChart = null;
+                }
+                document.getElementById('singleModeFiles').value = '';
+                selectedSignalsForComparison.length = 0;
+                updateSingleModeDisplay();
+                document.getElementById('plotSingleBtn').disabled = true;
+                document.getElementById('singleChartFullscreenBtn').disabled = true;
+            }
+
+            function plotMultipleCharts() {
+                if (selectedSignalsForMultiple.length === 0) return;
+
+                multipleChartsArray.forEach(chart => chart.destroy());
+                multipleChartsArray.length = 0;
+
+                const container = document.getElementById('multipleChartsContainer');
+
+                let gridClass = 'chart-grid ';
+                if (selectedSignalsForMultiple.length === 1) {
+                    gridClass += 'multiple-charts-1';
+                } else if (selectedSignalsForMultiple.length === 2) {
+                    gridClass += 'multiple-charts-2';
+                } else if (selectedSignalsForMultiple.length === 3) {
+                    gridClass += 'multiple-charts-3';
+                } else if (selectedSignalsForMultiple.length === 4) {
+                    gridClass += 'multiple-charts-4';
+                } else {
+                    gridClass += 'multiple-charts-more';
+                }
+
+                container.className = gridClass;
+                container.innerHTML = '';
+
+                selectedSignalsForMultiple.forEach((signal, index) => {
+                    const chartDiv = document.createElement('div');
+                    chartDiv.className = 'chart-container-preview';
+                    chartDiv.innerHTML = `
+                        <div class="chart-title">${signal.name}</div>
+                        <canvas id="multiChart_${index}"></canvas>
+                    `;
+                    container.appendChild(chartDiv);
+
+                    const ctx = document.getElementById(`multiChart_${index}`).getContext('2d');
+                    const data = parseSignalData(signal.content);
+
+                    const chart = new Chart(ctx, {
+                        type: 'line',
+                        data: {
+                            datasets: [{
+                                label: signal.name,
+                                data: data,
+                                borderColor: 'rgb(75, 192, 192)',
+                                backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                                fill: false,
+                                tension: 0.1,
+                                pointRadius: 0
+                            }]
+                        },
+                        options: {
+                            responsive: true,
+                            maintainAspectRatio: false,
+                            scales: {
+                                x: { type: 'linear', position: 'bottom', title: { display: true, text: 'Time' } },
+                                y: { title: { display: true, text: 'Signal Value' } }
+                            },
+                            plugins: {
+                                legend: { display: false },
+                                tooltip: { mode: 'index', intersect: false }
+                            }
+                        }
+                    });
+                    multipleChartsArray.push(chart);
+                });
+
+                document.getElementById('multipleChartsFullscreenBtn').disabled = false;
+            }
+
+            function clearMultipleCharts() {
+                multipleChartsArray.forEach(chart => chart.destroy());
+                multipleChartsArray.length = 0;
+                document.getElementById('multipleModeFiles').value = '';
+                selectedSignalsForMultiple.length = 0;
+                updateMultipleModeDisplay();
+                document.getElementById('plotMultipleBtn').disabled = true;
+                document.getElementById('multipleChartsFullscreenBtn').disabled = true;
+                const container = document.getElementById('multipleChartsContainer');
+                container.className = 'chart-grid';
+                container.innerHTML = `
+                    <div class="text-center text-muted">
+                        <p>Upload signal files and click "Plot All Charts" to view them</p>
+                    </div>`;
+            }
+
+            function loadSingleModeFiles() {
+                const input = document.getElementById('singleModeFiles');
+                const files = Array.from(input.files);
+
+                if (files.length === 0) {
+                    return;
+                }
+
+                selectedSignalsForComparison.length = 0;
+
+                files.forEach(file => {
+                    const reader = new FileReader();
+                    reader.onload = function(e) {
+                        selectedSignalsForComparison.push({ name: file.name, content: e.target.result });
+                        updateSingleModeDisplay();
+                        if (selectedSignalsForComparison.length === files.length) {
+                            document.getElementById('plotSingleBtn').disabled = false;
+                        }
+                    };
+                    reader.readAsText(file);
+                });
+            }
+
+            function loadMultipleModeFiles() {
+                const input = document.getElementById('multipleModeFiles');
+                const files = Array.from(input.files);
+
+                if (files.length === 0) {
+                    return;
+                }
+
+                selectedSignalsForMultiple.length = 0;
+
+                files.forEach(file => {
+                    const reader = new FileReader();
+                    reader.onload = function(e) {
+                        selectedSignalsForMultiple.push({ name: file.name, content: e.target.result });
+                        updateMultipleModeDisplay();
+                        if (selectedSignalsForMultiple.length === files.length) {
+                            document.getElementById('plotMultipleBtn').disabled = false;
+                        }
+                    };
+                    reader.readAsText(file);
+                });
+            }
+
+            function updateSingleModeDisplay() {
+                const container = document.getElementById('singleModeFilesList');
+                if (!container) return;
+
+                if (selectedSignalsForComparison.length === 0) {
+                    container.innerHTML = '<small class="text-muted">No files loaded</small>';
+                    return;
+                }
+
+                container.innerHTML = selectedSignalsForComparison.map(signal => `<div class="badge bg-primary me-1 mb-1">${signal.name}</div>`).join('');
+            }
+
+            function updateMultipleModeDisplay() {
+                const container = document.getElementById('multipleModeFilesList');
+                if (!container) return;
+
+                if (selectedSignalsForMultiple.length === 0) {
+                    container.innerHTML = '<small class="text-muted">No files loaded</small>';
+                    return;
+                }
+
+                container.innerHTML = selectedSignalsForMultiple.map(signal => `<div class="badge bg-info me-1 mb-1">${signal.name}</div>`).join('');
+            }
+
+            let fullscreenChart = null;
+            let fullscreenMultipleCharts = [];
+
+            function openSingleChartFullscreen() {
+                if (!singleComparisonChart) return;
+
+                const modal = document.getElementById('fullscreenModal');
+                const title = document.getElementById('fullscreenChartTitle');
+                const singleContainer = document.getElementById('fullscreenSingleChart');
+                const multipleContainer = document.getElementById('fullscreenMultipleCharts');
+                const canvas = document.getElementById('fullscreenChart');
+
+                singleContainer.style.display = 'flex';
+                multipleContainer.style.display = 'none';
+
+                title.textContent = 'Signal Comparison Chart - Fullscreen View';
+                modal.style.display = 'flex';
+
+                if (fullscreenChart) {
+                    fullscreenChart.destroy();
+                }
+
+                const originalData = singleComparisonChart.data;
+                const originalOptions = singleComparisonChart.options;
+
+                const ctx = canvas.getContext('2d');
+                fullscreenChart = new Chart(ctx, {
+                    type: 'line',
+                    data: JSON.parse(JSON.stringify(originalData)),
+                    options: {
+                        ...JSON.parse(JSON.stringify(originalOptions)),
+                        responsive: true,
+                        maintainAspectRatio: false
+                    }
+                });
+            }
+
+            function openMultipleChartsFullscreen() {
+                if (selectedSignalsForMultiple.length === 0) return;
+
+                const modal = document.getElementById('fullscreenModal');
+                const title = document.getElementById('fullscreenChartTitle');
+                const singleContainer = document.getElementById('fullscreenSingleChart');
+                const multipleContainer = document.getElementById('fullscreenMultipleCharts');
+
+                singleContainer.style.display = 'none';
+                multipleContainer.style.display = 'grid';
+
+                title.textContent = 'Multiple Signal Charts - Fullscreen View';
+                modal.style.display = 'flex';
+
+                fullscreenMultipleCharts.forEach(chart => chart.destroy());
+                fullscreenMultipleCharts.length = 0;
+
+                let gridClass = 'fullscreen-multiple-charts ';
+                if (selectedSignalsForMultiple.length === 1) {
+                    gridClass += 'charts-1';
+                } else if (selectedSignalsForMultiple.length === 2) {
+                    gridClass += 'charts-2';
+                } else if (selectedSignalsForMultiple.length === 3) {
+                    gridClass += 'charts-3';
+                } else if (selectedSignalsForMultiple.length === 4) {
+                    gridClass += 'charts-4';
+                } else {
+                    gridClass += 'charts-more';
+                }
+
+                multipleContainer.className = gridClass;
+                multipleContainer.innerHTML = '';
+
+                selectedSignalsForMultiple.forEach((signal, index) => {
+                    const chartDiv = document.createElement('div');
+                    chartDiv.className = 'fullscreen-chart-item';
+                    chartDiv.innerHTML = `
+                        <div class="fullscreen-chart-title">${signal.name}</div>
+                        <canvas id="fullscreenMultiChart_${index}"></canvas>
+                    `;
+                    multipleContainer.appendChild(chartDiv);
+
+                    const ctx = document.getElementById(`fullscreenMultiChart_${index}`).getContext('2d');
+                    const data = parseSignalData(signal.content);
+
+                    const chart = new Chart(ctx, {
+                        type: 'line',
+                        data: {
+                            datasets: [{
+                                label: signal.name,
+                                data: data,
+                                borderColor: 'rgb(75, 192, 192)',
+                                backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                                fill: false,
+                                tension: 0.1,
+                                pointRadius: 0
+                            }]
+                        },
+                        options: {
+                            responsive: true,
+                            maintainAspectRatio: false,
+                            scales: {
+                                x: { type: 'linear', position: 'bottom', title: { display: true, text: 'Time' } },
+                                y: { title: { display: true, text: 'Signal Value' } }
+                            },
+                            plugins: {
+                                legend: { display: true, position: 'top' },
+                                tooltip: { mode: 'index', intersect: false }
+                            }
+                        }
+                    });
+
+                    fullscreenMultipleCharts.push(chart);
+                });
+            }
+
+            function closeFullscreenChart() {
+                const modal = document.getElementById('fullscreenModal');
+                modal.style.display = 'none';
+
+                if (fullscreenChart) {
+                    fullscreenChart.destroy();
+                    fullscreenChart = null;
+                }
+
+                fullscreenMultipleCharts.forEach(chart => chart.destroy());
+                fullscreenMultipleCharts.length = 0;
+
+                document.getElementById('fullscreenSingleChart').style.display = 'none';
+                document.getElementById('fullscreenMultipleCharts').style.display = 'none';
+            }
+
+            document.addEventListener('keydown', function(event) {
+                if (event.key === 'Escape') {
+                    closeFullscreenChart();
+                }
+            });
+
+            document.getElementById('fullscreenModal').addEventListener('click', function(event) {
+                if (event.target === this) {
+                    closeFullscreenChart();
+                }
             });
         });
 


### PR DESCRIPTION
## Summary
- add advanced preview interface with fullscreen support
- allow comparing signals on a single chart or plotting multiple charts
- preserve textual anomaly output

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b21df50788328bb6dad8062160509