### PR TITLE
Enhance model management UI

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -7,19 +7,22 @@ let persistentConfig = {
       url: process.env.SVM_MODEL_URL || 'http://localhost:8001/predict',
       enabled: true,
       trainingUrl: process.env.SVM_TRAINING_URL || 'http://localhost:8001/train',
-      healthUrl: process.env.SVM_HEALTHCHECK_URL || 'http://localhost:8001/health'
+      healthUrl: process.env.SVM_HEALTHCHECK_URL || 'http://localhost:8001/health',
+      displayName: 'SVM'
     },
     lstm: {
       url: process.env.LSTM_MODEL_URL || 'http://localhost:8002/predict',
       enabled: true,
       trainingUrl: process.env.LSTM_TRAINING_URL || 'http://localhost:8002/train',
-      healthUrl: process.env.LSTM_HEALTHCHECK_URL || 'http://localhost:8002/health'
+      healthUrl: process.env.LSTM_HEALTHCHECK_URL || 'http://localhost:8002/health',
+      displayName: 'LSTM'
     },
     xgboost: {
       url: process.env.XGBOOST_MODEL_URL || 'http://localhost:8003/predict',
       enabled: true,
       trainingUrl: process.env.XGBOOST_TRAINING_URL || 'http://localhost:8003/train',
-      healthUrl: process.env.XGBOOST_HEALTHCHECK_URL || 'http://localhost:8003/health'
+      healthUrl: process.env.XGBOOST_HEALTHCHECK_URL || 'http://localhost:8003/health',
+      displayName: 'XGBoost'
     }
   }
 };
@@ -46,7 +49,31 @@ module.exports = {
       persistentConfig.models[modelName].trainingUrl = url;
     } else if (type === 'health') {
       persistentConfig.models[modelName].healthUrl = url;
-    } 
+    }
+  },
+
+  // Actualiza el nombre visible de un modelo
+  updateModelDisplayName(modelName, displayName) {
+    if (!persistentConfig.models[modelName]) {
+      throw new Error(`Modelo '${modelName}' no encontrado`);
+    }
+    persistentConfig.models[modelName].displayName = displayName;
+  },
+
+  // Agrega un nuevo modelo a la configuración
+  addModel(name, urls) {
+    const key = name.toLowerCase().replace(/\s+/g, '_');
+    if (persistentConfig.models[key]) {
+      throw new Error(`El modelo '${name}' ya existe`);
+    }
+    persistentConfig.models[key] = {
+      url: urls.url,
+      trainingUrl: urls.trainingUrl,
+      healthUrl: urls.healthUrl,
+      enabled: true,
+      displayName: name
+    };
+    return key;
   },
   
   // Request timeouts

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -75,6 +75,14 @@ module.exports = {
     };
     return key;
   },
+
+  // Elimina un modelo de la configuración
+  removeModel(modelName) {
+    if (!persistentConfig.models[modelName]) {
+      throw new Error(`Modelo '${modelName}' no encontrado`);
+    }
+    delete persistentConfig.models[modelName];
+  },
   
   // Request timeouts
   timeouts: {

--- a/src/controllers/orchestrator.controller.js
+++ b/src/controllers/orchestrator.controller.js
@@ -141,7 +141,8 @@ class OrchestratorController {
           enabled: config.models[modelName].enabled,
           url: config.models[modelName].url,
           trainingUrl: config.models[modelName].trainingUrl,
-          healthUrl: config.models[modelName].healthUrl
+          healthUrl: config.models[modelName].healthUrl,
+          displayName: config.models[modelName].displayName
         })),
         timeout: config.timeouts.model
       };
@@ -188,7 +189,8 @@ class OrchestratorController {
           enabled: config.models[model].enabled,
           url: config.models[model].url,
           trainingUrl: config.models[model].trainingUrl,
-          healthUrl: config.models[model].healthUrl
+          healthUrl: config.models[model].healthUrl,
+          displayName: config.models[model].displayName
         }))
       });
     } catch (error) {
@@ -239,11 +241,87 @@ class OrchestratorController {
           enabled: config.models[model].enabled,
           url: config.models[model].url,
           trainingUrl: config.models[model].trainingUrl,
-          healthUrl: config.models[model].healthUrl
+          healthUrl: config.models[model].healthUrl,
+          displayName: config.models[model].displayName
         }))
       });
     } catch (error) {
       logger.error(`Error al actualizar URL: ${error.message}`);
+      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        error: error.message
+      });
+    }
+  }
+
+  /**
+   * Actualiza el nombre visible de un modelo
+   */
+  async updateModelName(req, res) {
+    try {
+      const { modelName, displayName } = req.body;
+
+      if (!modelName || !displayName) {
+        return res.status(StatusCodes.BAD_REQUEST).json({
+          error: 'Se requiere nombre de modelo y nuevo nombre'
+        });
+      }
+
+      if (!config.models[modelName]) {
+        return res.status(StatusCodes.NOT_FOUND).json({
+          error: `Modelo '${modelName}' no encontrado`
+        });
+      }
+
+      config.updateModelDisplayName(modelName, displayName);
+
+      return res.status(StatusCodes.OK).json({
+        message: `Nombre del modelo '${modelName}' actualizado`,
+        models: Object.keys(config.models).map(model => ({
+          name: model,
+          enabled: config.models[model].enabled,
+          url: config.models[model].url,
+          trainingUrl: config.models[model].trainingUrl,
+          healthUrl: config.models[model].healthUrl,
+          displayName: config.models[model].displayName
+        }))
+      });
+    } catch (error) {
+      logger.error(`Error al actualizar nombre: ${error.message}`);
+      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        error: error.message
+      });
+    }
+  }
+
+  /**
+   * Agrega un nuevo modelo a la configuración
+   */
+  async addModel(req, res) {
+    try {
+      const { name, url, trainingUrl, healthUrl } = req.body;
+
+      if (!name || !url || !trainingUrl || !healthUrl) {
+        return res.status(StatusCodes.BAD_REQUEST).json({
+          error: 'Se requiere nombre y todas las URLs del modelo'
+        });
+      }
+
+      const key = config.addModel(name, { url, trainingUrl, healthUrl });
+
+      return res.status(StatusCodes.OK).json({
+        message: `Modelo '${name}' agregado`,
+        key,
+        models: Object.keys(config.models).map(model => ({
+          name: model,
+          enabled: config.models[model].enabled,
+          url: config.models[model].url,
+          trainingUrl: config.models[model].trainingUrl,
+          healthUrl: config.models[model].healthUrl,
+          displayName: config.models[model].displayName
+        }))
+      });
+    } catch (error) {
+      logger.error(`Error al agregar modelo: ${error.message}`);
       return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
         error: error.message
       });

--- a/src/controllers/orchestrator.controller.js
+++ b/src/controllers/orchestrator.controller.js
@@ -327,6 +327,46 @@ class OrchestratorController {
       });
     }
   }
+
+  /**
+   * Elimina un modelo de la configuración
+   */
+  async deleteModel(req, res) {
+    try {
+      const { modelName } = req.body;
+
+      if (!modelName) {
+        return res.status(StatusCodes.BAD_REQUEST).json({
+          error: 'Se requiere nombre de modelo'
+        });
+      }
+
+      if (!config.models[modelName]) {
+        return res.status(StatusCodes.NOT_FOUND).json({
+          error: `Modelo '${modelName}' no encontrado`
+        });
+      }
+
+      config.removeModel(modelName);
+
+      return res.status(StatusCodes.OK).json({
+        message: `Modelo '${modelName}' eliminado`,
+        models: Object.keys(config.models).map(model => ({
+          name: model,
+          enabled: config.models[model].enabled,
+          url: config.models[model].url,
+          trainingUrl: config.models[model].trainingUrl,
+          healthUrl: config.models[model].healthUrl,
+          displayName: config.models[model].displayName
+        }))
+      });
+    } catch (error) {
+      logger.error(`Error al eliminar modelo: ${error.message}`);
+      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        error: error.message
+      });
+    }
+  }
 }
 
 module.exports = new OrchestratorController();

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -18,5 +18,6 @@ router.post('/config/model', validateModelConfig, orchestratorController.updateM
 router.post('/config/url', orchestratorController.updateModelUrl);
 router.post('/config/model/name', orchestratorController.updateModelName);
 router.post('/config/model/add', orchestratorController.addModel);
+router.post('/config/model/delete', orchestratorController.deleteModel);
 
 module.exports = router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -16,5 +16,7 @@ router.get('/health', orchestratorController.health);
 router.get('/config', orchestratorController.getConfig);
 router.post('/config/model', validateModelConfig, orchestratorController.updateModelConfig);
 router.post('/config/url', orchestratorController.updateModelUrl);
+router.post('/config/model/name', orchestratorController.updateModelName);
+router.post('/config/model/add', orchestratorController.addModel);
 
 module.exports = router;

--- a/src/utils/socket.js
+++ b/src/utils/socket.js
@@ -7,11 +7,10 @@ const orchestratorService = require('../services/orchestrator.service');
  */
 module.exports = function(io) {
   // Mantener registro del estado de los modelos
-  const modelStatus = {
-    svm: { status: 'unknown', lastCheck: null },
-    lstm: { status: 'unknown', lastCheck: null },
-    xgboost: { status: 'unknown', lastCheck: null }
-  };
+  const modelStatus = {};
+  Object.keys(orchestratorService.models).forEach(name => {
+    modelStatus[name] = { status: 'unknown', lastCheck: null };
+  });
 
   // Registro de predicciones realizadas
   const predictionLog = [];

--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -1108,18 +1108,27 @@
             const displayName = modelDisplayNames[name] || name;
 
             return `
-                <div class="model-col">
-                    <div class="card model-card">
+                <div class="model-col" id="model-col-${name}">
+                    <div class="card model-card" id="model-card-${name}">
                         <div class="card-body">
-                            <h5 class="card-title editable-name" data-model="${name}" contenteditable="true">${displayName}</h5>
+                            <div class="d-flex justify-content-between align-items-start">
+                                <h5 class="card-title m-0">
+                                    <span class="editable-name" data-model="${name}" contenteditable="true">${displayName}</span>
+                                </h5>
+                                <span class="delete-model" data-model="${name}" style="cursor:pointer" title="Delete">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x-circle" viewBox="0 0 16 16">
+                                        <path d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm3.354-9.354a.5.5 0 1 1 .708.708L8.707 8l3.355 3.354a.5.5 0 0 1-.708.708L8 8.707l-3.354 3.355a.5.5 0 1 1-.708-.708L7.293 8 3.939 4.646a.5.5 0 1 1 .708-.708L8 7.293l3.354-3.647z"/>
+                                    </svg>
+                                </span>
+                            </div>
                             <p class="model-status ${statusClass}">${statusText}</p>
                             <p class="card-text">
-                                <small class="text-muted">Last check: ${lastCheck}</small>
+                                <small class="text-muted model-lastcheck">Last check: ${lastCheck}</small>
                             </p>
                             <div class="form-check form-switch">
-                                <input class="form-check-input model-toggle" type="checkbox" 
-                                    id="toggle-${name}" 
-                                    data-model="${name}" 
+                                <input class="form-check-input model-toggle" type="checkbox"
+                                    id="toggle-${name}"
+                                    data-model="${name}"
                                     ${status.status !== 'disabled' ? 'checked' : ''}>
                                 <label class="form-check-label" for="toggle-${name}">Enabled</label>
                             </div>
@@ -2016,8 +2025,16 @@
 
             return appliedCount;
         }        // Socket event listeners
+        let currentModelStatus = {};
         socket.on('health-update', function(modelStatus) {
-            renderModels(modelStatus);
+            currentModelStatus = modelStatus;
+            const container = document.getElementById('modelsContainer');
+            const cards = container.querySelectorAll('.model-col').length;
+            if (cards !== Object.keys(modelStatus).length) {
+                renderModels(modelStatus);
+            } else {
+                updateModelStatuses(modelStatus);
+            }
         });
 
         socket.on('prediction-result', function(result) {
@@ -2063,19 +2080,11 @@
             // You can add error handling/notification here if desired
         });
 
-        // Function to render all models
-        function renderModels(modelStatus) {
-            const container = document.getElementById('modelsContainer');
-            let html = '';
-            
-            for (const [modelName, status] of Object.entries(modelStatus)) {
-                html += renderModel(modelName, status);
-            }
-            
-            container.innerHTML = html;
-
-            // Add event listeners to model toggles
+        function attachModelListeners(container) {
+            // toggles
             container.querySelectorAll('.model-toggle').forEach(toggle => {
+                if (toggle.dataset.listener) return;
+                toggle.dataset.listener = 'true';
                 toggle.addEventListener('change', function() {
                     const modelName = this.dataset.model;
                     const enabled = this.checked;
@@ -2083,8 +2092,10 @@
                 });
             });
 
-            // Add event listeners to editable names
+            // editable names
             container.querySelectorAll('.editable-name').forEach(span => {
+                if (span.dataset.listener) return;
+                span.dataset.listener = 'true';
                 span.addEventListener('keydown', function(e) {
                     if (e.key === 'Enter') {
                         e.preventDefault();
@@ -2100,14 +2111,75 @@
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
                             body: JSON.stringify({ modelName, displayName: newName })
-                        })
-                        .then(res => res.json())
-                        .then(() => {
+                        }).then(res => res.json()).then(() => {
                             modelDisplayNames[modelName] = newName;
                         });
                     }
                 });
             });
+
+            // delete buttons
+            container.querySelectorAll('.delete-model').forEach(btn => {
+                if (btn.dataset.listener) return;
+                btn.dataset.listener = 'true';
+                btn.addEventListener('click', async function() {
+                    const modelName = this.dataset.model;
+                    if (!confirm(`Delete model '${modelDisplayNames[modelName] || modelName}'?`)) return;
+                    await fetch('/api/config/model/delete', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ modelName })
+                    });
+                    const cfg = await fetch('/api/config').then(r => r.json());
+                    modelDisplayNames = {};
+                    cfg.models.forEach(m => {
+                        modelDisplayNames[m.name] = m.displayName || m.name;
+                    });
+                    socket.emit('request-health');
+                });
+            });
+        }
+
+        function renderModels(modelStatus) {
+            const container = document.getElementById('modelsContainer');
+            let html = '';
+            for (const [modelName, status] of Object.entries(modelStatus)) {
+                html += renderModel(modelName, status);
+            }
+            container.innerHTML = html;
+            attachModelListeners(container);
+        }
+
+        function updateModelStatuses(modelStatus) {
+            for (const [name, status] of Object.entries(modelStatus)) {
+                const card = document.getElementById(`model-card-${name}`);
+                if (!card) continue;
+                const statusClass = {
+                    'online': 'status-online',
+                    'offline': 'status-offline',
+                    'disabled': 'status-disabled',
+                    'unknown': 'status-unknown'
+                }[status.status] || 'status-unknown';
+
+                const statusText = {
+                    'online': 'Online',
+                    'offline': 'Offline',
+                    'disabled': 'Disabled',
+                    'unknown': 'Unknown'
+                }[status.status] || 'Unknown';
+
+                const lastCheck = status.lastCheck ? formatDate(status.lastCheck) : 'Never';
+
+                const statusEl = card.querySelector('.model-status');
+                statusEl.className = `model-status ${statusClass}`;
+                statusEl.textContent = statusText;
+
+                const lastEl = card.querySelector('.model-lastcheck');
+                if (lastEl) lastEl.textContent = `Last check: ${lastCheck}`;
+
+                const toggle = card.querySelector('.model-toggle');
+                if (toggle) toggle.checked = status.status !== 'disabled';
+            }
         }
 
         // When DOM is ready

--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -524,8 +524,9 @@
         <div class="row mb-4">
             <div class="col-12">
                 <div class="card">
-                    <div class="card-header bg-primary text-white">
-                        Model Status
+                    <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
+                        <span>Model Status</span>
+                        <button class="btn btn-light btn-sm" id="addModelBtn">Add Model</button>
                     </div>
                     <div class="card-body">
                         <div class="models-row" id="modelsContainer">
@@ -1080,6 +1081,7 @@
         // Array of training downloads. Each download has: id, files[], anomalyTime
         let discharges = [];
         let dischargeCounter = 0;
+        let modelDisplayNames = {};
 
         function formatDate(date) {
             const d = new Date(date);
@@ -1103,11 +1105,13 @@
 
             const lastCheck = status.lastCheck ? formatDate(status.lastCheck) : 'Never';
 
+            const displayName = modelDisplayNames[name] || name;
+
             return `
                 <div class="model-col">
                     <div class="card model-card">
                         <div class="card-body">
-                            <h5 class="card-title">${name.toUpperCase()}</h5>
+                            <h5 class="card-title editable-name" data-model="${name}" contenteditable="true">${displayName}</h5>
                             <p class="model-status ${statusClass}">${statusText}</p>
                             <p class="card-text">
                                 <small class="text-muted">Last check: ${lastCheck}</small>
@@ -1769,7 +1773,7 @@
                 html += `
                     <div class="card mb-3">
                         <div class="card-header">
-                            <h5 class="mb-0">${model.name.toUpperCase()}</h5>
+                            <h5 class="mb-0">${(model.displayName || model.name).toUpperCase()}</h5>
                         </div>
                         <div class="card-body">
                             <div class="form-check form-switch mb-3">
@@ -2069,13 +2073,39 @@
             }
             
             container.innerHTML = html;
-            
+
             // Add event listeners to model toggles
             container.querySelectorAll('.model-toggle').forEach(toggle => {
                 toggle.addEventListener('change', function() {
                     const modelName = this.dataset.model;
                     const enabled = this.checked;
                     socket.emit('toggle-model', { modelName, enabled });
+                });
+            });
+
+            // Add event listeners to editable names
+            container.querySelectorAll('.editable-name').forEach(span => {
+                span.addEventListener('keydown', function(e) {
+                    if (e.key === 'Enter') {
+                        e.preventDefault();
+                        this.blur();
+                    }
+                });
+
+                span.addEventListener('blur', function() {
+                    const modelName = this.dataset.model;
+                    const newName = this.textContent.trim();
+                    if (newName && modelDisplayNames[modelName] !== newName) {
+                        fetch('/api/config/model/name', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ modelName, displayName: newName })
+                        })
+                        .then(res => res.json())
+                        .then(() => {
+                            modelDisplayNames[modelName] = newName;
+                        });
+                    }
                 });
             });
         }
@@ -2085,6 +2115,38 @@
             predictionDetailsModal = new bootstrap.Modal(document.getElementById('predictionDetailsModal'));
             configModal = new bootstrap.Modal(document.getElementById('configModal'));
             filePreviewModal = new bootstrap.Modal(document.getElementById('filePreviewModal'));
+
+            fetch('/api/config')
+                .then(response => response.json())
+                .then(cfg => {
+                    cfg.models.forEach(m => {
+                        modelDisplayNames[m.name] = m.displayName || m.name;
+                    });
+                });
+
+            document.getElementById('addModelBtn').addEventListener('click', async function () {
+                const name = prompt('Model name:');
+                if (!name) return;
+                const url = prompt('Prediction URL:');
+                if (!url) return;
+                const trainingUrl = prompt('Training URL:');
+                if (!trainingUrl) return;
+                const healthUrl = prompt('Health URL:');
+                if (!healthUrl) return;
+
+                await fetch('/api/config/model/add', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ name, url, trainingUrl, healthUrl })
+                });
+
+                const cfg = await fetch('/api/config').then(r => r.json());
+                modelDisplayNames = {};
+                cfg.models.forEach(m => {
+                    modelDisplayNames[m.name] = m.displayName || m.name;
+                });
+                socket.emit('request-health');
+            });
 
             document.getElementById('refreshBtn').addEventListener('click', function () {
                 socket.emit('request-health');


### PR DESCRIPTION
## Summary
- add display name field to model configuration
- support adding models dynamically via API
- allow updating model display names
- initialize socket model status dynamically
- make model names editable and add button to create models in dashboard

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_684dc5f470dc8328abd66e29aa4f677a