### PR TITLE
Update orchestrator to outlier node protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # outlier_orchestrator
 
-This repository implements the orchestrator for our disruption prediction system. Messages are described at the [outlier protocol](https://github.com/outlierClassifier/outlier_protocol).
+This repository implements the orchestrator for our disruption prediction system. Messages are described at the [outlier protocol](https://github.com/outlierClassifier/outlier_protocol). The orchestrator now speaks the **outlier node protocol v0.1.0** when communicating with prediction nodes.
 
 ## Installation
 
@@ -21,6 +21,7 @@ cp .env.example .env
 ## API Endpoints
 
 See [outlier_protocol](https://github.com/outlierClassifier/outlier_protocol) for detailed API specifications.
+The orchestrator also exposes `/api/train/raw` for uploading sensor text files directly. This endpoint parses the files server-side and starts the training session using the outlier node protocol.
 
 ## Developed with
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,19 @@ cp .env.example .env
 ## API Endpoints
 
 See [outlier_protocol](https://github.com/outlierClassifier/outlier_protocol) for detailed API specifications.
-The orchestrator also exposes `/api/train/raw` for uploading sensor text files directly. Use a `multipart/form-data` request where each file field is named `dischargeN` (starting from `discharge0`). A JSON `metadata` field specifies discharge ids and anomaly times. The backend parses the files and starts the training session using the outlier node protocol.
+The orchestrator also exposes `/api/train/raw` for uploading sensor text files directly. Use a `multipart/form-data` request where each file field is named `dischargeN` (starting from `discharge0`). A JSON `metadata` field specifies discharge ids. The backend parses the files and starts the training session using the outlier node protocol. Each discharge sent to the models includes:
+
+```json
+{
+  "id": "123",
+  "times": [0.0, 0.02, ...],
+  "length": 1000,
+  "signals": [
+    { "filename": "sensor1.txt", "values": [1, 2, 3] },
+    { "filename": "sensor2.txt", "values": [4, 5, 6] }
+  ]
+}
+```
 
 ## Developed with
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cp .env.example .env
 ## API Endpoints
 
 See [outlier_protocol](https://github.com/outlierClassifier/outlier_protocol) for detailed API specifications.
-The orchestrator also exposes `/api/train/raw` for uploading sensor text files directly. This endpoint parses the files server-side and starts the training session using the outlier node protocol.
+The orchestrator also exposes `/api/train/raw` for uploading sensor text files directly. Use a `multipart/form-data` request where each file field is named `dischargeN` (starting from `discharge0`). A JSON `metadata` field specifies discharge ids and anomaly times. The backend parses the files and starts the training session using the outlier node protocol.
 
 ## Developed with
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "express": "^5.1.0",
         "http-status-codes": "^2.3.0",
         "morgan": "^1.10.0",
+        "multer": "^2.0.1",
         "socket.io": "^4.8.1",
         "winston": "^3.17.0"
       },
@@ -141,6 +142,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -251,6 +258,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -427,6 +451,21 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/config": {
       "version": "3.3.12",
@@ -1303,6 +1342,27 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/morgan": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
@@ -1351,6 +1411,67 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.1.tgz",
+      "integrity": "sha512-Ug8bXeTIUlxurg8xLTEskKShvcKDZALo1THEX5E41pYCD2sCVub5/kIRIGqWNoqV6szyLyQKV6mD4QUrWE5GCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "mkdirp": "^0.5.6",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.18",
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -1937,6 +2058,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -2019,6 +2148,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",
@@ -2118,6 +2253,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "express": "^5.1.0",
     "http-status-codes": "^2.3.0",
     "morgan": "^1.10.0",
+    "multer": "^2.0.1",
     "socket.io": "^4.8.1",
     "winston": "^3.17.0"
   },

--- a/src/controllers/orchestrator.controller.js
+++ b/src/controllers/orchestrator.controller.js
@@ -101,6 +101,38 @@ class OrchestratorController {
   }
 
   /**
+   * Procesa descargas en bruto y las envía a los modelos para entrenamiento
+   * @param {Request} req
+   * @param {Response} res
+   */
+  async trainRaw(req, res) {
+    try {
+      const { discharges } = req.body || {};
+
+      if (!discharges || !Array.isArray(discharges) || discharges.length === 0) {
+        return res.status(StatusCodes.BAD_REQUEST).json({
+          error: 'Se requieren descargas con archivos para entrenar'
+        });
+      }
+
+      const parsed = orchestratorService.prepareTrainingData(discharges);
+
+      const result = await orchestratorService.trainModels(parsed);
+
+      return res.status(StatusCodes.OK).json({
+        message: 'Entrenamiento iniciado correctamente',
+        details: result
+      });
+    } catch (error) {
+      logger.error(`Error en entrenamiento raw: ${error.message}`);
+      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        error: 'Error al procesar la petición de entrenamiento',
+        message: error.message
+      });
+    }
+  }
+
+  /**
    * Obtiene el estado de salud de los modelos
    * @param {Request} req - Objeto de solicitud HTTP
    * @param {Response} res - Objeto de respuesta HTTP

--- a/src/middleware/validation.middleware.js
+++ b/src/middleware/validation.middleware.js
@@ -39,72 +39,44 @@ function validatedischargealData(req, res, next) {
           error: `La descarga ${discharge.id} debe tener al menos un sensor`
         });
       }
-      
-      // Si tiene tiempos a nivel de descarga, validarlos
-      if (discharge.times) {
-        if (!Array.isArray(discharge.times) || discharge.times.length === 0) {
-          return res.status(StatusCodes.BAD_REQUEST).json({
-            error: `La descarga ${discharge.id} tiene un formato de tiempos inválido`
-          });
-        }
-        
-        // Verificar que todos los valores son numéricos
-        if (discharge.times.some(value => typeof value !== 'number' || isNaN(value))) {
-          return res.status(StatusCodes.BAD_REQUEST).json({
-            error: `La descarga ${discharge.id} tiene valores de tiempo no numéricos`
-          });
-        }
+
+      if (!Array.isArray(discharge.times) || discharge.times.length === 0) {
+        return res.status(StatusCodes.BAD_REQUEST).json({
+          error: `La descarga ${discharge.id} debe incluir un array de tiempos`
+        });
       }
-      
+
+      if (discharge.times.some(value => typeof value !== 'number' || isNaN(value))) {
+        return res.status(StatusCodes.BAD_REQUEST).json({
+          error: `La descarga ${discharge.id} tiene valores de tiempo no numéricos`
+        });
+      }
+
       // Validar señales
       for (const sensor of discharge.signals) {
         // Verificar nombre de archivo
-        if (!sensor.fileName) {
+        if (!sensor.filename) {
           return res.status(StatusCodes.BAD_REQUEST).json({
             error: `Sensor sin nombre de archivo en descarga ${discharge.id}`
           });
         }
-        
+
         // Verificar valores
         if (!Array.isArray(sensor.values) || sensor.values.length === 0) {
           return res.status(StatusCodes.BAD_REQUEST).json({
-            error: `El sensor ${sensor.fileName} del descarga ${discharge.id} debe tener un array de valores no vacío`
+            error: `El sensor ${sensor.filename} del descarga ${discharge.id} debe tener un array de valores no vacío`
           });
         }
-        
-        // Si el descarga no tiene tiempos comunes, el sensor debe tenerlos
-        if (!discharge.times) {
-          if (!Array.isArray(sensor.times) || sensor.times.length === 0) {
-            return res.status(StatusCodes.BAD_REQUEST).json({
-              error: `El sensor ${sensor.fileName} del descarga ${discharge.id} debe tener un array de tiempos cuando no hay tiempos a nivel de descarga`
-            });
-          }
-          
-          if (sensor.times.length !== sensor.values.length) {
-            return res.status(StatusCodes.BAD_REQUEST).json({
-              error: `El sensor ${sensor.fileName} del descarga ${discharge.id} tiene diferentes longitudes para tiempos (${sensor.times.length}) y valores (${sensor.values.length})`
-            });
-          }
-          
-          // Verificar que los tiempos son numéricos
-          if (sensor.times.some(value => typeof value !== 'number' || isNaN(value))) {
-            return res.status(StatusCodes.BAD_REQUEST).json({
-              error: `El sensor ${sensor.fileName} del descarga ${discharge.id} tiene valores de tiempo no numéricos`
-            });
-          }
-        } else {
-          // Si hay tiempos a nivel de descarga, verificar que las longitudes coincidan
-          if (discharge.times.length !== sensor.values.length) {
-            return res.status(StatusCodes.BAD_REQUEST).json({
-              error: `El sensor ${sensor.fileName} del descarga ${discharge.id} tiene una longitud de valores (${sensor.values.length}) que no coincide con la longitud de tiempos del descarga (${discharge.times.length})`
-            });
-          }
+
+        if (discharge.times.length !== sensor.values.length) {
+          return res.status(StatusCodes.BAD_REQUEST).json({
+            error: `El sensor ${sensor.filename} del descarga ${discharge.id} tiene una longitud de valores (${sensor.values.length}) que no coincide con la longitud de tiempos (${discharge.times.length})`
+          });
         }
-        
-        // Verificar que los valores son numéricos
+
         if (sensor.values.some(value => typeof value !== 'number' || isNaN(value))) {
           return res.status(StatusCodes.BAD_REQUEST).json({
-            error: `El sensor ${sensor.fileName} del descarga ${discharge.id} tiene valores no numéricos`
+            error: `El sensor ${sensor.filename} del descarga ${discharge.id} tiene valores no numéricos`
           });
         }
       }

--- a/src/models/sensor-data.model.js
+++ b/src/models/sensor-data.model.js
@@ -10,7 +10,7 @@ class SensorData {
    * @param {Number|null} anomalyTime - Tiempo en el que ocurre la anomalía (null si no hay anomalía)
    */
   constructor(fileName, times, values, anomalyTime = null) {
-    this.fileName = fileName;
+    this.filename = fileName;
     this.times = times;
     this.values = values;
     this.length = times.length;
@@ -55,7 +55,7 @@ class SensorData {
    */
   toJSON() {
     return {
-      fileName: this.fileName,
+      filename: this.filename,
       times: this.times,
       values: this.values,
       length: this.length,

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -8,6 +8,7 @@ router.post('/predict', validatedischargealData, orchestratorController.predict)
 
 // Ruta para entrenamiento de modelos
 router.post('/train', validatedischargealData, orchestratorController.train);
+router.post('/train/raw', orchestratorController.trainRaw);
 
 // Ruta para verificar la salud de los servicios
 router.get('/health', orchestratorController.health);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,6 +1,9 @@
 const express = require('express');
+const multer = require('multer');
 const orchestratorController = require('../controllers/orchestrator.controller');
 const { validatedischargealData, validateModelConfig } = require('../middleware/validation.middleware');
+
+const upload = multer();
 const router = express.Router();
 
 // Ruta para realizar predicciones
@@ -8,7 +11,7 @@ router.post('/predict', validatedischargealData, orchestratorController.predict)
 
 // Ruta para entrenamiento de modelos
 router.post('/train', validatedischargealData, orchestratorController.train);
-router.post('/train/raw', orchestratorController.trainRaw);
+router.post('/train/raw', upload.any(), orchestratorController.trainRaw);
 
 // Ruta para verificar la salud de los servicios
 router.get('/health', orchestratorController.health);

--- a/src/services/orchestrator.service.js
+++ b/src/services/orchestrator.service.js
@@ -19,34 +19,40 @@ class OrchestratorService {
    * @param {Object} data - Datos para la predicción (formato discharges)
    * @returns {Promise} - Promesa con la respuesta del modelo
    */
-  async callModel(modelName, data) {
+  async callModel(modelName, discharge) {
     try {
       const modelConfig = this.models[modelName];
-      
+
       if (!modelConfig || !modelConfig.enabled) {
         logger.warn(`Model ${modelName} is not enabled or does not exist`);
         return { error: `Model ${modelName} is not available`, modelName };
       }
-      
+
       logger.info(`Sending data to ${modelName} model at ${modelConfig.url}`);
-      
+
       const response = await axios({
         method: 'post',
         url: modelConfig.url,
-        data,
+        data: discharge,
         timeout: this.timeout
       });
-      
+
       logger.info(`Received response from ${modelName} model`);
-      return { 
-        result: response.data,
+
+      let prediction = response.data.prediction;
+      if (typeof prediction === 'string') {
+        prediction = prediction.toLowerCase() === 'anomaly' ? 1 : 0;
+      }
+
+      return {
+        result: { ...response.data, prediction },
         modelName,
         status: 'success'
       };
     } catch (error) {
       logger.error(`Error calling ${modelName} model: ${error.message}`);
-      return { 
-        error: error.message, 
+      return {
+        error: error.message,
         modelName,
         status: 'error'
       };
@@ -62,31 +68,45 @@ class OrchestratorService {
   async trainModel(modelName, data) {
     try {
       const modelConfig = this.models[modelName];
-      
+
       if (!modelConfig || !modelConfig.enabled) {
         logger.warn(`Model ${modelName} is not enabled or does not exist for training`);
         return { error: `Model ${modelName} is not available`, modelName };
       }
-      
-      logger.info(`Sending training data to ${modelName} model at ${modelConfig.trainingUrl}`);
-      
-      const response = await axios({
+
+      const totalDischarges = data.discharges.length;
+      const timeoutSeconds = Math.ceil(this.trainingTimeout / 1000);
+
+      logger.info(`Starting training session on ${modelName} at ${modelConfig.trainingUrl}`);
+
+      const startResponse = await axios({
         method: 'post',
         url: modelConfig.trainingUrl,
-        data,
+        data: { totalDischarges, timeoutSeconds },
         timeout: this.trainingTimeout
       });
-      
-      logger.info(`Received training response from ${modelName} model`);
-      return { 
-        result: response.data,
+
+      logger.info(`Model ${modelName} accepted training session expecting ${startResponse.data.expectedDischarges} discharges`);
+
+      for (let i = 0; i < totalDischarges; i++) {
+        const discharge = data.discharges[i];
+        await axios({
+          method: 'post',
+          url: `${modelConfig.trainingUrl}/${i + 1}`,
+          data: discharge,
+          timeout: this.trainingTimeout
+        });
+      }
+
+      return {
+        result: startResponse.data,
         modelName,
         status: 'success'
       };
     } catch (error) {
       logger.error(`Error training ${modelName} model: ${error.message}`);
-      return { 
-        error: error.message, 
+      return {
+        error: error.message,
         modelName,
         status: 'error'
       };
@@ -119,9 +139,11 @@ class OrchestratorService {
       throw new Error('No models are enabled for prediction');
     }
     
-    // Llamadas en paralelo a todos los modelos
-    const modelPromises = enabledModels.map(model => 
-      this.callModel(model, data)
+    const discharge = data.discharges[0];
+
+    // Llamadas en paralelo a todos los modelos con la nueva estructura
+    const modelPromises = enabledModels.map(model =>
+      this.callModel(model, discharge)
     );
     
     // Esperar todas las respuestas (con timeout)
@@ -336,6 +358,31 @@ class OrchestratorService {
     }
     
     return { signals };
+  }
+
+  /**
+   * Convierte descargas en bruto (con archivos) en el formato
+   * requerido por el protocolo outlier.
+   * @param {Array<Object>} rawDischarges - Descargas con archivos {name, content}
+   * @returns {Object} - Objeto con el arreglo "discharges" procesado
+   */
+  prepareTrainingData(rawDischarges = []) {
+    const discharges = rawDischarges.map((d, idx) => {
+      if (!d.files || d.files.length === 0) {
+        throw new Error(`Discharge ${d.id || idx} has no files`);
+      }
+
+      const { signals } = this.parseSensorFiles(d.files);
+      const discharge = { id: d.id || `discharge_${idx + 1}`, signals };
+
+      if (d.anomalyTime !== undefined) {
+        discharge.anomalyTime = d.anomalyTime;
+      }
+
+      return discharge;
+    });
+
+    return { discharges };
   }
 }
 

--- a/src/services/orchestrator.service.js
+++ b/src/services/orchestrator.service.js
@@ -345,18 +345,21 @@ class OrchestratorService {
    */
   parseSensorFiles(files, anomalyTimes = {}) {
     const signals = [];
-    
+
     for (const file of files) {
       try {
-        const anomalyTime = anomalyTimes[file.name] || null;
-        const sensorData = SensorData.fromTextFile(file.name, file.content, anomalyTime);
+        const name = file.name || file.originalname;
+        const content = file.content || (file.buffer ? file.buffer.toString('utf8') : '');
+        const anomalyTime = anomalyTimes[name] || null;
+        const sensorData = SensorData.fromTextFile(name, content, anomalyTime);
         signals.push(sensorData);
       } catch (error) {
-        logger.error(`Error parsing sensor file ${file.name}: ${error.message}`);
-        throw new Error(`Error parsing sensor file ${file.name}: ${error.message}`);
+        const fname = file.name || file.originalname;
+        logger.error(`Error parsing sensor file ${fname}: ${error.message}`);
+        throw new Error(`Error parsing sensor file ${fname}: ${error.message}`);
       }
     }
-    
+
     return { signals };
   }
 

--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -2650,14 +2650,14 @@
             // Event listener for processing discharges for training
             document.getElementById('processDischargesBtn').addEventListener('click', function () {
                 try {
-                    const trainingData = processDischargesForTraining();
+                    const payload = { discharges };
 
-                    fetch('/api/train', {
+                    fetch('/api/train/raw', {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json'
                         },
-                        body: JSON.stringify(trainingData)
+                        body: JSON.stringify(payload)
                     })
                         .then(response => response.json())
                         .then(result => {

--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -648,7 +648,7 @@
                                         <div class="mb-3">
                                             <label for="testDataTextarea" class="form-label">Data (JSON format)</label>
                                             <textarea class="form-control" id="testDataTextarea" rows="8"
-                                                placeholder='{ "signals": [{ "fileName": "sensor1.txt", "times": [41.052, 41.054, ...], "values": [-759337, -760461, ...], "length": 5, "anomalyTime": null }] }'></textarea>
+                                                placeholder='{ "signals": [{ "filename": "sensor1.txt", "times": [41.052, 41.054, ...], "values": [-759337, -760461, ...], "length": 5 }] }'></textarea>
                                         </div>
                                         <div class="d-grid">
                                             <button id="testPredictionBtn" class="btn btn-primary">Predict</button>
@@ -790,7 +790,7 @@
                                             <label for="trainingDataTextarea" class="form-label">Data (JSON
                                                 format)</label>
                                             <textarea class="form-control" id="trainingDataTextarea" rows="8"
-                                                placeholder='{ "signals": [{ "fileName": "sensor1.txt", "times": [41.052, 41.054, ...], "values": [-759337, -760461, ...], "length": 5, "anomalyTime": 41.056 }] }'></textarea>
+                                                placeholder='{ "signals": [{ "filename": "sensor1.txt", "times": [41.052, 41.054, ...], "values": [-759337, -760461, ...], "length": 5 }] }'></textarea>
                                         </div>
                                         <div class="d-grid">
                                             <button id="startTrainingBtn" class="btn btn-warning">Start
@@ -1771,8 +1771,7 @@
                     if (!dischargeGroups[dischargeId]) {
                         dischargeGroups[dischargeId] = {
                             id: dischargeId,
-                            files: [],
-                            commonTimes: null
+                            files: []
                         };
                     }
 
@@ -1811,7 +1810,7 @@
                         signals: []
                     };
 
-                    if (allSameTime && firstFileTimes && firstFileTimes.length > 0) {
+                    if (firstFileTimes && firstFileTimes.length > 0) {
                         discharge.times = firstFileTimes;
                         discharge.length = firstFileTimes.length;
                     }
@@ -1832,16 +1831,10 @@
                         }
 
                         const sensorData = {
-                            fileName: file.name,
+                            filename: file.name,
                             values: values
                         };
-
-                        // If times are not common, include them in the sensor data
-                        if (!allSameTime) {
-                            sensorData.times = times;
-                            sensorData.length = times.length;
-                        }
-
+                    
                         discharge.signals.push(sensorData);
                     });
 
@@ -1890,14 +1883,8 @@
                         signals: []
                     };
 
-                    if (discharge.anomalyTime !== null) {
-                        dischargeData.anomalyTime = discharge.anomalyTime;
-                    }
-
-                    let commonTimes = null;
                     let firstFileTimes = null;
                     let allSameTime = true;
-                    const values = [];
 
                     // Process first all times to check if they are common
                     discharge.files.forEach((file, index) => {
@@ -1923,7 +1910,7 @@
                         }
                     });
 
-                    if (allSameTime && firstFileTimes) {
+                    if (firstFileTimes) {
                         dischargeData.times = firstFileTimes;
                         dischargeData.length = firstFileTimes.length;
                     }
@@ -1933,7 +1920,6 @@
                         try {
                             const lines = file.content.trim().split('\n');
                             const values = [];
-                            let fileTimes = [];
 
                             for (const line of lines) {
                                 const parts = line.trim().split(/\s+/);
@@ -1943,24 +1929,15 @@
 
                                     if (!isNaN(time) && !isNaN(value)) {
                                         // If we don't have common times, store the times per file
-                                        if (!allSameTime) {
-                                            fileTimes.push(time);
-                                        }
-                                        values.push(value);
+                                    values.push(value);
                                     }
                                 }
                             }
 
                             const sensorData = {
-                                fileName: file.name,
+                                filename: file.name,
                                 values: values
                             };
-
-                            // If there are no common times, include the specific times of the file
-                            if (!allSameTime) {
-                                sensorData.times = fileTimes;
-                                sensorData.length = fileTimes.length;
-                            }
 
                             dischargeData.signals.push(sensorData);
 

--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -1445,21 +1445,16 @@
             });
 
             container.querySelectorAll('.discharge-files-input').forEach(input => {
-                input.addEventListener('change', async function (e) {
+                input.addEventListener('change', function (e) {
                     const dischargeId = parseInt(this.getAttribute('data-discharge-id'));
                     const dischargeIndex = discharges.findIndex(d => d.id === dischargeId);
 
                     if (dischargeIndex !== -1 && e.target.files.length > 0) {
                         for (const file of e.target.files) {
-                            try {
-                                const content = await readFileAsText(file);
-                                discharges[dischargeIndex].files.push({
-                                    name: file.name,
-                                    content
-                                });
-                            } catch (error) {
-                                alert(`Error at reading file ${file.name}: ${error.message}`);
-                            }
+                            discharges[dischargeIndex].files.push({
+                                name: file.name,
+                                file
+                            });
                         }
 
                         renderDischarges();
@@ -1490,7 +1485,7 @@
 
                     if (dischargeIndex !== -1 && discharges[dischargeIndex].files[fileIndex]) {
                         const file = discharges[dischargeIndex].files[fileIndex];
-                        showFilePreview(file.name, file.content);
+                        showFilePreview(file.name, file.file);
                     }
                 });
             });
@@ -1549,112 +1544,14 @@
                 return;
             }
 
-            // Create data structure for the preview with optimized format
-            const previewData = { discharges: [] };
+            const previewData = {
+                discharges: discharges.map(d => ({
+                    id: d.id,
+                    anomalyTime: d.anomalyTime,
+                    files: d.files.map(f => f.name)
+                }))
+            };
 
-            // Process each discharge
-            discharges.forEach(discharge => {
-                if (discharge.files.length === 0) {
-                    return; // Skip discharges without files
-                }
-
-                let dischargeId = `discharge_${discharge.id + 1}`;
-
-                // Try to extract the identifier from the file name
-                if (discharge.files.length > 0) {
-                    const fileName = discharge.files[0].name;
-                    const match = fileName.match(/DES_(\d+)/i);
-                    if (match && match[1]) {
-                        dischargeId = match[1];
-                    }
-                }
-
-                const dischargeData = {
-                    id: dischargeId,
-                    signals: []
-                };
-
-                // Add anomaly time if defined
-                if (discharge.anomalyTime !== null) {
-                    dischargeData.anomalyTime = discharge.anomalyTime;
-                }
-
-                // Check if all files have the same times
-                let commonTimes = [];
-                let allSameTime = true;
-                let firstFileTimes = null;
-
-                // Take the first 5 lines for the preview
-                discharge.files.forEach((file, index) => {
-                    const lines = file.content.trim().split('\n');
-                    const previewLines = Math.min(5, lines.length);
-                    const times = [];
-
-                    for (let i = 0; i < previewLines; i++) {
-                        const parts = lines[i].trim().split(/\s+/);
-                        if (parts.length >= 2) {
-                            times.push(parseFloat(parts[0]));
-                        }
-                    }
-
-                    if (index === 0) {
-                        firstFileTimes = times;
-                    } else if (JSON.stringify(times) !== JSON.stringify(firstFileTimes)) {
-                        allSameTime = false;
-                    }
-                });
-
-                if (allSameTime && firstFileTimes) {
-                    dischargeData.times = firstFileTimes;
-                    const totalLines = discharge.files[0].content.trim().split('\n').length;
-                    dischargeData.length = totalLines;
-                    if (totalLines > 5) {
-                        dischargeData._previewNote = `... displaying 5 of ${totalLines} lines`;
-                    }
-                }
-
-                // Process each file
-                discharge.files.forEach(file => {
-                    try {
-                        const lines = file.content.trim().split('\n');
-                        const previewLines = Math.min(5, lines.length);
-                        const times = [];
-                        const values = [];
-
-                        for (let i = 0; i < previewLines; i++) {
-                            const line = lines[i].trim();
-                            const parts = line.split(/\s+/);
-                            if (parts.length >= 2) {
-                                if (!allSameTime) {
-                                    times.push(parseFloat(parts[0]));
-                                }
-                                values.push(parseFloat(parts[1]));
-                            }
-                        }
-
-                        const sensorData = {
-                            fileName: file.name,
-                            values: values
-                        };
-
-                        // Solo incluimos tiempos si no son comunes
-                        if (!allSameTime) {
-                            sensorData.times = times;
-                            const totalLines = file.content.trim().split('\n').length;
-                            sensorData.length = totalLines;
-                            if (totalLines > 5) {
-                                sensorData._previewNote = `... showing 5 of ${totalLines} lines`;
-                            }
-                        }
-
-                        dischargeData.signals.push(sensorData);
-                    } catch (error) {
-                        console.error(`Error processing file ${file.name}:`, error);
-                    }
-                });
-
-                previewData.discharges.push(dischargeData);
-            });            // Format the JSON for display
             document.getElementById('jsonPreview').textContent = JSON.stringify(previewData, null, 2);
         }
 
@@ -1674,20 +1571,13 @@
                 return;
             }
 
-            // Read all files
-            Promise.all(files.map(file => {
-                return readFileAsText(file).then(content => ({
-                    name: file.name,
-                    content: content,
-                    file: file
-                }));
-            })).then(filesData => {
-                selectedMultipleFiles = filesData;
-                updateMultipleDischargeFilesPreview();
-                document.getElementById('testPatternsBtn').disabled = false;
-            }).catch(error => {
-                alert(`Error reading files: ${error.message}`);
-            });
+            // Store file references only
+            selectedMultipleFiles = files.map(file => ({
+                name: file.name,
+                file: file
+            }));
+            updateMultipleDischargeFilesPreview();
+            document.getElementById('testPatternsBtn').disabled = false;
         }
 
         function updateMultipleDischargeFilesPreview() {
@@ -1829,7 +1719,7 @@
                     if (fileData) {
                         discharge.files.push({
                             name: fileData.name,
-                            content: fileData.content
+                            file: fileData.file
                         });
                     }
                 });
@@ -2219,7 +2109,12 @@
         };
 
         // File preview with graph visualization
-        function showFilePreview(fileName, content, anomalyTime = null) {
+        function showFilePreview(fileName, fileOrContent, anomalyTime = null) {
+            const loadContent = typeof fileOrContent === 'string'
+                ? Promise.resolve(fileOrContent)
+                : readFileAsText(fileOrContent);
+
+            loadContent.then(content => {
             // Store reference to any existing chart to destroy it
             let chartInstance = window.signalChartInstance;
             if (chartInstance) {
@@ -2294,6 +2189,7 @@
 
             // Show the modal
             filePreviewModal.show();
+        });
         }
 
         function parseDisruptionTimesFile(content) {
@@ -2650,14 +2546,22 @@
             // Event listener for processing discharges for training
             document.getElementById('processDischargesBtn').addEventListener('click', function () {
                 try {
-                    const payload = { discharges };
+                    const metadata = {
+                        discharges: discharges.map(d => ({ id: d.id, anomalyTime: d.anomalyTime }))
+                    };
+
+                    const formData = new FormData();
+                    formData.append('metadata', JSON.stringify(metadata));
+
+                    discharges.forEach((discharge, idx) => {
+                        discharge.files.forEach(f => {
+                            formData.append(`discharge${idx}`, f.file, f.name);
+                        });
+                    });
 
                     fetch('/api/train/raw', {
                         method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json'
-                        },
-                        body: JSON.stringify(payload)
+                        body: formData
                     })
                         .then(response => response.json())
                         .then(result => {


### PR DESCRIPTION
## Summary
- support new outlier node protocol when calling models
- add backend endpoint to handle raw training uploads
- adjust dashboard to send raw discharges
- note raw training endpoint in README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6855995f4a708328b8fdf286a49443b3