### PR TITLE
Add download buttons for prediction history

### DIFF
--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -1235,21 +1235,30 @@
                 const confidenceWidth = prediction.confidence ? (prediction.confidence * 100) : 0;
 
                 return `
-                    <div class="prediction-item prediction-class-${predClass}" 
-                         data-index="${index}" 
+                    <div class="prediction-item prediction-class-${predClass}"
+                         data-index="${index}"
                          onclick="showPredictionDetails(${index})">
                         <div class="d-flex justify-content-between">
                             <strong>Clase: ${predClass !== 'undefined' ? predClass : 'Undefined'}</strong>
                             <span class="timestamp">${formatDate(prediction.timestamp)}</span>
                         </div>
-                        
+
                         <div class="confidence-bar">
                             <div class="confidence-value" style="width: ${confidenceWidth}%"></div>
                         </div>
-                        
+
                         <div class="d-flex justify-content-between mt-2">
                             <small>Confianza: ${(prediction.confidence * 100).toFixed(1)}%</small>
                             <small>Votos: ${JSON.stringify(prediction.votes)}</small>
+                        </div>
+                        <div class="mt-2 text-end">
+                            <button class="btn btn-sm btn-outline-secondary" title="Download JSON"
+                                    onclick="downloadPrediction(${index}, event)">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-download" viewBox="0 0 16 16">
+                                    <path d="M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5z"/>
+                                    <path d="M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708l3 3z"/>
+                                </svg>
+                            </button>
                         </div>
                     </div>
                 `;
@@ -1922,6 +1931,23 @@
                     JSON.stringify(prediction.details, null, 2);
                 predictionDetailsModal.show();
             }
+        };
+
+        window.downloadPrediction = function (index, event) {
+            if (event) event.stopPropagation();
+            const prediction = predictionHistory[index];
+            if (!prediction) return;
+
+            const blob = new Blob([JSON.stringify(prediction, null, 2)], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const ts = prediction.timestamp ? new Date(prediction.timestamp).toISOString().replace(/[:.]/g, '-') : index;
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `prediction_${ts}.json`;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
         };
 
         // File preview with graph visualization


### PR DESCRIPTION
## Summary
- enable downloading of single prediction records as JSON files
- implement frontend download logic in dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ca043d58c832880a6fdaa2cfb4528